### PR TITLE
Set to use simpler Ejecta fork

### DIFF
--- a/src/leiningen/new/ejecta_cljs/Podfile
+++ b/src/leiningen/new/ejecta_cljs/Podfile
@@ -1,3 +1,3 @@
 platform :ios, '8.0'
 pod 'Ambly', :git => 'https://github.com/mfikes/ambly', :branch => 'jsc-c-api'
-pod 'Ejecta', :git => 'https://github.com/mfikes/Ejecta', :branch => 'podspec'
+pod 'Ejecta', :git => 'https://github.com/swannodette/Ejecta', :branch => 'podspec'

--- a/src/leiningen/new/ejecta_cljs/Podfile
+++ b/src/leiningen/new/ejecta_cljs/Podfile
@@ -1,3 +1,3 @@
 platform :ios, '8.0'
-pod 'Ambly', :git => 'https://github.com/mfikes/ambly', :branch => 'jsc-c-api'
+pod 'Ambly', :git => 'https://github.com/omcljs/ambly', :branch => 'jsc-c-api'
 pod 'Ejecta', :git => 'https://github.com/swannodette/Ejecta', :branch => 'podspec'


### PR DESCRIPTION
I turns out that David Nolen's simpler Ejecta fork
works just fine. Mike Fikes's subsequent revisions
to David's fork are unnnecesary.
