### PR TITLE
Update to Ambly 0.4.0

### DIFF
--- a/src/leiningen/new/ejecta_cljs/Podfile
+++ b/src/leiningen/new/ejecta_cljs/Podfile
@@ -1,3 +1,3 @@
 platform :ios, '8.0'
-pod 'Ambly', :git => 'https://github.com/omcljs/ambly', :branch => 'jsc-c-api'
+pod 'Ambly', '~> 0.4.0'
 pod 'Ejecta', :git => 'https://github.com/swannodette/Ejecta', :branch => 'podspec'


### PR DESCRIPTION
Ambly 0.4.0 uses the JavaScriptCore C API
